### PR TITLE
Enhance Frost Lab session controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,63 +1,154 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>In Loving Memory of Bodhi 🐾</title>
-  <link rel="stylesheet" href="style.css">
-</head>
-<body class="theme-serene">
-  <div class="header">
-    <h1>In Loving Memory of Bodhi 🐾</h1>
-    <h2>18/12/24</h2>
-    <button id="themeToggle">🌗 Toggle Theme</button>
-    <button id="muteToggle">🔊 Mute/Unmute Music</button>
-    <button id="fireworksButton">🎇 Launch Fireworks</button>
-    <button id="balloonButton">🎈 Release Balloons</button>
-    <button id="confettiButton">🎊 Throw Confetti</button>
-    <button id="lanternButton">🏮 Light Lanterns</button>
-  </div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Frostborne Ice Lab</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="brand">❄️ Frostborne Lab</div>
+      <nav class="nav-links">
+        <a href="#hero" class="nav-link">Story</a>
+        <a href="#shop" class="nav-link">Shop</a>
+        <a href="#unboxing" class="nav-link">Frost Lab</a>
+      </nav>
+      <div class="session-pill" id="sessionStatus">Guest session</div>
+    </header>
 
-  <div id="visitorCount"></div>
+    <section class="login-banner" id="loginBanner">
+      <div class="banner-text" id="bannerText">
+        <strong>Claim your lab pass.</strong> Save a display name to track pulls
+        and inventory.
+      </div>
+      <div class="banner-form" id="bannerForm">
+        <input
+          type="text"
+          id="nameInput"
+          placeholder="Display name"
+          aria-label="Display name"
+        />
+        <button id="saveName">Save name</button>
+        <button id="clearName" class="ghost" aria-label="Switch display name">
+          Switch name
+        </button>
+      </div>
+    </section>
 
-  <div id="share">
-    <h3>Share this memorial 💞</h3>
-    <button id="shareButton">Share Link</button>
-  </div>
+    <main>
+      <section id="hero" class="hero">
+        <div class="hero-copy">
+          <p class="eyebrow">Glacier-crafted | Small batch</p>
+          <h1>Ice forged for storytellers.</h1>
+          <p class="lede">
+            Frostborne captures the character of polar storms—obsidian shards,
+            aurora-lit fractures, and the shimmer of impossible cold. Every cube
+            is tempered for clarity, carved for ritual, and stamped with our
+            crest.
+          </p>
+          <div class="cta-row">
+            <a class="cta primary" data-target="#shop" href="#shop"
+              >Order Signature Ice</a
+            >
+            <a class="cta ghost" data-target="#unboxing" href="#unboxing"
+              >Start Unboxing</a
+            >
+          </div>
+          <ul class="hero-stats">
+            <li><span>72 hr</span> slow freeze</li>
+            <li><span>7x</span> filtered melt</li>
+            <li><span>Carbon-neutral</span> deliveries</li>
+          </ul>
+        </div>
+        <div class="hero-visual">
+          <div class="frost-orb">
+            <div class="frost-core"></div>
+            <div class="halo"></div>
+          </div>
+          <div class="rarity-meter" aria-label="Rarity meter">
+            <div class="meter-label">Drop rate preview</div>
+            <div class="meter-bars" id="rarityBars"></div>
+          </div>
+        </div>
+      </section>
 
-  <div class="centerpiece">
-    <img src="assets/bodhi.png" alt="Bodhi" class="bodhi-img" onclick="angelWings()">
-  </div>
+      <section id="shop" class="section">
+        <div class="section-header">
+          <div>
+            <p class="eyebrow">Signature collection</p>
+            <h2>Shop the frostline.</h2>
+          </div>
+          <a class="cta link" data-target="#unboxing" href="#unboxing"
+            >Unbox a lab crate →</a
+          >
+        </div>
+        <div id="productGrid" class="product-grid"></div>
+      </section>
 
-  <div id="candles">
-    <h3>Light a Candle 🕯️</h3>
-    <input id="candleName" placeholder="Your name">
-    <button onclick="lightCandle()">🕯️ Light Candle</button>
-    <div id="candleArea"></div>
-  </div>
+      <section id="unboxing" class="section frost-lab">
+        <div class="section-header">
+          <div>
+            <p class="eyebrow">Frost Lab</p>
+            <h2>Crack open a portal crate.</h2>
+            <p class="lede">
+              Test your luck, unlock variants, and log every pull to your
+              display name.
+            </p>
+          </div>
+          <div class="lab-actions">
+            <a class="cta primary" id="labCta" href="#unboxing"
+              >Start Unboxing</a
+            >
+            <a class="cta ghost" data-target="#shop" href="#shop"
+              >Return to shop</a
+            >
+          </div>
+        </div>
 
-  <div id="gifts">
-    <h3>Leave a Gift 🎁 (Drag onto page)</h3>
-    <button onclick="leaveGift('🌹')">🌹 Rose</button>
-    <button onclick="leaveGift('🦴')">🦴 Bone</button>
-    <button onclick="leaveGift('❤️')">❤️ Heart</button>
-  </div>
+        <div class="lab-grid">
+          <div class="lab-portal">
+            <div class="portal-frame">
+              <div class="portal-core">
+                <div class="portal-ring"></div>
+                <div class="portal-flare"></div>
+              </div>
+              <div class="crate">▢ Frost Crate</div>
+            </div>
+            <button id="unboxButton" class="cta primary wide">
+              Engage Portal
+            </button>
+            <div class="drop-result" id="dropResult">Awaiting input.</div>
+            <div class="legend" id="rarityLegend"></div>
+          </div>
 
-  <div id="guestbook">
-    <h3>Guestbook 📖</h3>
-    <textarea id="messageInput" placeholder="Leave your message..."></textarea>
-    <button onclick="addMessage()">Submit</button>
-    <ul id="messages"></ul>
-  </div>
+          <div class="lab-inventory">
+            <div class="panel" id="inventoryPanel">
+              <div class="panel-header">
+                <div>
+                  <p class="eyebrow">Inventory</p>
+                  <h3>Lab pulls by rarity</h3>
+                </div>
+                <span class="pill" id="inventoryStatus">Locked</span>
+              </div>
+              <div class="inventory-grid" id="inventoryGrid"></div>
+            </div>
 
-  <div id="music">
-    <iframe id="musicFrame" width="0" height="0"
-      src="https://www.youtube.com/embed/gPYODbvQgD4?autoplay=1&loop=1&playlist=gPYODbvQgD4"
-      frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-  </div>
+            <div class="panel" id="historyPanel">
+              <div class="panel-header">
+                <div>
+                  <p class="eyebrow">History</p>
+                  <h3>Latest portal events</h3>
+                </div>
+                <span class="pill ghost" id="historyStatus">Guest</span>
+              </div>
+              <ul class="history" id="historyList"></ul>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
 
-  <canvas id="fireworksCanvas"></canvas>
-
-  <script src="script.js"></script>
-</body>
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,60 +1,316 @@
-function randomPosition(max){return Math.floor(Math.random()*max);}
-function createHeart(){const e=document.createElement('div');e.className='heart';
-e.style.left=randomPosition(window.innerWidth)+'px';e.innerHTML=Math.random()>0.5?'💖':'🌹';
-document.body.appendChild(e);setTimeout(()=>{e.remove();},10000);}setInterval(createHeart,400);
-document.getElementById('balloonButton').addEventListener('click',()=>{
-  const b=document.createElement('div');b.className='balloon';b.style.left=randomPosition(window.innerWidth)+'px';
-  b.innerHTML='🎈';b.style.top='100%';b.style.animation='fall 10s linear infinite reverse';document.body.appendChild(b);
-  setTimeout(()=>{b.remove();},10000);});
-document.getElementById('confettiButton').addEventListener('click',()=>{
-  for(let i=0;i<30;i++){const c=document.createElement('div');c.className='confetti';c.style.left=randomPosition(window.innerWidth)+'px';
-  c.innerHTML='🎊';document.body.appendChild(c);setTimeout(()=>{c.remove();},5000);} });
-document.getElementById('lanternButton').addEventListener('click',()=>{
-  for(let i=0;i<5;i++){const l=document.createElement('div');l.className='lantern';l.style.left=randomPosition(window.innerWidth)+'px';
-  l.innerHTML='🏮';l.style.top='100%';l.style.animation='fall 20s linear infinite reverse';document.body.appendChild(l);
-  setTimeout(()=>{l.remove();},20000);} });
-function lightCandle(){const n=document.getElementById('candleName').value||"Anonymous";
-const area=document.getElementById('candleArea');const c=document.createElement('div');c.className='candle';
-c.innerHTML='🕯️ '+n;area.appendChild(c);const candles=JSON.parse(localStorage.getItem('candles')||'[]');
-candles.push(n);localStorage.setItem('candles',JSON.stringify(candles));}
-function loadCandles(){const candles=JSON.parse(localStorage.getItem('candles')||'[]');
-const area=document.getElementById('candleArea');candles.forEach(n=>{const c=document.createElement('div');
-c.className='candle';c.innerHTML='🕯️ '+n;area.appendChild(c);});}loadCandles();
-function leaveGift(i){const g=document.createElement('span');g.className='gift';g.innerHTML=i;
-g.style.position='absolute';g.style.left=randomPosition(window.innerWidth-50)+'px';
-g.style.top=randomPosition(window.innerHeight-50)+'px';document.body.appendChild(g);
-const gifts=JSON.parse(localStorage.getItem('gifts')||'[]');gifts.push({icon:i,x:g.style.left,y:g.style.top});
-localStorage.setItem('gifts',JSON.stringify(gifts));}
-function loadGifts(){const gifts=JSON.parse(localStorage.getItem('gifts')||'[]');
-gifts.forEach(o=>{const g=document.createElement('span');g.className='gift';g.innerHTML=o.icon;g.style.position='absolute';
-g.style.left=o.x;g.style.top=o.y;document.body.appendChild(g);});}loadGifts();
-function addMessage(){const i=document.getElementById('messageInput');const m=i.value.trim();
-if(m){const msgs=JSON.parse(localStorage.getItem('messages')||'[]');msgs.push(m);
-localStorage.setItem('messages',JSON.stringify(msgs));displayMessages();i.value='';}}
-function displayMessages(){const msgs=JSON.parse(localStorage.getItem('messages')||'[]');const ul=document.getElementById('messages');
-ul.innerHTML='';msgs.forEach(m=>{const li=document.createElement('li');li.textContent=m;ul.appendChild(li);});}displayMessages();
-document.getElementById('themeToggle').addEventListener('click',()=>{
-document.body.classList.toggle('theme-emo');document.body.classList.toggle('theme-serene');});
-document.getElementById('muteToggle').addEventListener('click',()=>{const f=document.getElementById('musicFrame');
-f.src=f.src.includes('mute=1')?f.src.replace('mute=1','mute=0'):f.src+'&mute=1';});
-const canvas=document.getElementById('fireworksCanvas');const ctx=canvas.getContext('2d');
-canvas.width=window.innerWidth;canvas.height=window.innerHeight;
-class Firework{constructor(x,y,c){this.x=x;this.y=y;this.c=c;this.p=[];for(let i=0;i<100;i++){this.p.push({x:x,y:y,
-a:Math.random()*2*Math.PI,s:Math.random()*5+2,r:2,l:100});}}update(){this.p.forEach(p=>{p.x+=Math.cos(p.a)*p.s;
-p.y+=Math.sin(p.a)*p.s;p.l-=2;});this.p=this.p.filter(p=>p.l>0);}draw(){this.p.forEach(p=>{ctx.beginPath();
-ctx.arc(p.x,p.y,p.r,0,Math.PI*2);ctx.fillStyle=this.c[Math.floor(Math.random()*this.c.length)];ctx.fill();});}}
-let fw=[];function launchFirework(x,y){const c=['#ff66ff','#ff3399','#ffcc00','#00ccff','#ffffff'];fw.push(new Firework(x,y,c));}
-document.getElementById('fireworksButton').addEventListener('click',()=>{launchFirework(randomPosition(window.innerWidth),randomPosition(window.innerHeight/2));});
-function animate(){ctx.clearRect(0,0,canvas.width,canvas.height);fw.forEach(f=>{f.update();f.draw(ctx);});fw=fw.filter(f=>f.p.length>0);requestAnimationFrame(animate);}animate();
-window.addEventListener('resize',()=>{canvas.width=window.innerWidth;canvas.height=window.innerHeight;});
-function angelWings(){const w=document.createElement('div');w.className='angel-wings';w.innerHTML='🪽🪽';
-document.body.appendChild(w);setTimeout(()=>{w.remove();},6000);}
+const products = [
+  {
+    name: "Signature Glacier Block",
+    desc: 'Crystal-clear, slow-tempered cubes cut to a perfect 2.25".',
+    price: "$28",
+    tag: "Limited",
+    color: "linear-gradient(135deg, #7ee8fa, #80ffea)",
+  },
+  {
+    name: "Aurora Sphere Set",
+    desc: "Spheres infused with aurora shimmer for glass-forward pours.",
+    price: "$32",
+    tag: "Glow",
+    color: "linear-gradient(135deg, #9b8cff, #7ee8fa)",
+  },
+  {
+    name: "Obsidian Fracture",
+    desc: "Dark-charcoal chips for smoky spirits and nightcaps.",
+    price: "$18",
+    tag: "Small batch",
+    color: "linear-gradient(135deg, #1f273d, #9b8cff)",
+  },
+  {
+    name: "Tundra Sticks",
+    desc: "Stir-ready spears designed for highballs and spritzes.",
+    price: "$22",
+    tag: "Bar ready",
+    color: "linear-gradient(135deg, #80ffea, #ffd166)",
+  },
+  {
+    name: "Runic Crest Stamp",
+    desc: "Custom crest pressed into each cube for ceremonial service.",
+    price: "$15",
+    tag: "Custom",
+    color: "linear-gradient(135deg, #ffd166, #ff7eb6)",
+  },
+  {
+    name: "Polar Smoke Capsule",
+    desc: "Aromatics you can freeze into cubes for a drifting fog pour.",
+    price: "$24",
+    tag: "New",
+    color: "linear-gradient(135deg, #7ee8fa, #9b8cff)",
+  },
+];
 
-function updateVisitorCount(){let c=Number(localStorage.getItem('visitCount')||0)+1;localStorage.setItem('visitCount',c);document.getElementById('visitorCount').textContent='You are visitor #'+c;}
-updateVisitorCount();
+const lootTable = [
+  { name: "Prismatic Core", rarity: "Legendary", weight: 2, color: "#ff7eb6" },
+  { name: "Aurora Edge", rarity: "Epic", weight: 6, color: "#9b8cff" },
+  { name: "Glacial Crest", rarity: "Rare", weight: 18, color: "#7ee8fa" },
+  {
+    name: "Frostline Sample",
+    rarity: "Uncommon",
+    weight: 28,
+    color: "#80ffea",
+  },
+  { name: "Carbon Chill", rarity: "Common", weight: 46, color: "#8fa4c3" },
+];
 
-document.getElementById('shareButton').addEventListener('click',async()=>{
-  const data={title:'Bodhi Memorial Shrine',text:'Remembering Bodhi 🐾',url:window.location.href};
-  if(navigator.share){try{await navigator.share(data);}catch(e){console.error(e);}}
-  else{navigator.clipboard.writeText(data.url).then(()=>alert('Link copied to clipboard!'));}
-});
+const rarityWeights = lootTable.reduce((acc, item) => acc + item.weight, 0);
+let displayName = "";
+
+function refreshBannerState() {
+  const bannerText = document.getElementById("bannerText");
+  const bannerForm = document.getElementById("bannerForm");
+  const clearButton = document.getElementById("clearName");
+  const banner = document.getElementById("loginBanner");
+
+  const active = Boolean(displayName);
+  banner.classList.toggle("active", active);
+  bannerForm.classList.toggle("has-name", active);
+  clearButton.style.display = active ? "inline-flex" : "none";
+
+  if (active) {
+    bannerText.innerHTML = `<strong>Session active.</strong> Welcome, ${displayName}. Portal pulls will log to your name.`;
+  } else {
+    bannerText.innerHTML = `<strong>Claim your lab pass.</strong> Save a display name to track pulls and inventory.`;
+  }
+}
+
+function renderProducts() {
+  const grid = document.getElementById("productGrid");
+  grid.innerHTML = products
+    .map(
+      (product) => `
+    <article class="card">
+      <span class="badge" style="background:${product.color}">${product.tag}</span>
+      <h3>${product.name}</h3>
+      <p class="tagline">${product.desc}</p>
+      <div class="price">${product.price}</div>
+    </article>
+  `,
+    )
+    .join("");
+}
+
+function renderRarityMeter() {
+  const bars = document.getElementById("rarityBars");
+  bars.innerHTML = lootTable
+    .map((item) => {
+      const percent = Math.round((item.weight / rarityWeights) * 100);
+      return `
+      <div class="meter-row">
+        <span>${item.rarity}</span>
+        <div class="meter-track">
+          <div class="meter-fill" style="width:${percent}%;background:${item.color}"></div>
+        </div>
+        <div class="percent">${percent}%</div>
+      </div>
+    `;
+    })
+    .join("");
+}
+
+function renderLegend() {
+  const legend = document.getElementById("rarityLegend");
+  legend.innerHTML = lootTable
+    .map(
+      (item) => `
+    <div class="legend-item">
+      <span class="legend-swatch" style="background:${item.color}"></span>
+      <div>
+        <strong>${item.rarity}</strong>
+        <div class="muted">${item.name}</div>
+      </div>
+    </div>
+  `,
+    )
+    .join("");
+}
+
+function updateSessionUI() {
+  const status = document.getElementById("sessionStatus");
+  const pill = displayName ? `Logged in as ${displayName}` : "Guest session";
+  status.textContent = pill;
+  document.getElementById("inventoryStatus").textContent = displayName
+    ? "Live"
+    : "Locked";
+  document.getElementById("historyStatus").textContent = displayName
+    ? displayName
+    : "Guest";
+
+  document
+    .getElementById("inventoryPanel")
+    .classList.toggle("locked", !displayName);
+  document
+    .getElementById("historyPanel")
+    .classList.toggle("locked", !displayName);
+
+  refreshBannerState();
+}
+
+function saveName() {
+  const input = document.getElementById("nameInput");
+  const name = input.value.trim();
+  if (!name) return;
+  displayName = name;
+  localStorage.setItem("displayName", displayName);
+  input.value = "";
+  updateSessionUI();
+  loadInventory();
+  loadHistory();
+  document.getElementById("dropResult").textContent =
+    `Session locked to ${displayName}. Engage portal when ready.`;
+}
+
+function loadName() {
+  displayName = localStorage.getItem("displayName") || "";
+  updateSessionUI();
+  if (displayName) {
+    document.getElementById("dropResult").textContent =
+      `Welcome back, ${displayName}. Engage the portal when ready.`;
+  }
+}
+
+function clearName() {
+  localStorage.removeItem("displayName");
+  displayName = "";
+  updateSessionUI();
+  loadInventory();
+  loadHistory();
+  document.getElementById("dropResult").textContent = "Awaiting input.";
+  document.getElementById("nameInput").focus();
+}
+
+function weightedPull() {
+  const roll = Math.random() * rarityWeights;
+  let cursor = 0;
+  for (const item of lootTable) {
+    cursor += item.weight;
+    if (roll <= cursor) return item;
+  }
+  return lootTable[lootTable.length - 1];
+}
+
+function getInventoryKey() {
+  return displayName ? `inventory_${displayName}` : null;
+}
+
+function loadInventory() {
+  const grid = document.getElementById("inventoryGrid");
+  if (!displayName) {
+    grid.innerHTML = `<div class="muted">Save a display name to track inventory.</div>`;
+    return;
+  }
+  const key = getInventoryKey();
+  const stored = JSON.parse(localStorage.getItem(key) || "{}");
+  grid.innerHTML = lootTable
+    .map((item) => {
+      const count = stored[item.rarity] || 0;
+      return `
+      <div class="inventory-card" style="border-color:${item.color}33">
+        <span>${item.rarity}</span>
+        <div class="muted">${item.name}</div>
+        <strong>${count} pulled</strong>
+      </div>
+    `;
+    })
+    .join("");
+}
+
+function loadHistory() {
+  const list = document.getElementById("historyList");
+  if (!displayName) {
+    list.innerHTML = `<li class="muted">Pull history unlocks after you save a name.</li>`;
+    return;
+  }
+  const history = JSON.parse(
+    localStorage.getItem(`history_${displayName}`) || "[]",
+  );
+  if (!history.length) {
+    list.innerHTML = `<li class="muted">No pulls yet. Engage the portal.</li>`;
+    return;
+  }
+  list.innerHTML = history
+    .slice(-6)
+    .reverse()
+    .map(
+      (entry) => `
+    <li><strong>${entry.item}</strong> · ${entry.rarity} · ${new Date(entry.time).toLocaleString()}</li>
+  `,
+    )
+    .join("");
+}
+
+function savePull(item) {
+  const key = getInventoryKey();
+  if (!key) return;
+  const inv = JSON.parse(localStorage.getItem(key) || "{}");
+  inv[item.rarity] = (inv[item.rarity] || 0) + 1;
+  localStorage.setItem(key, JSON.stringify(inv));
+
+  const historyKey = `history_${displayName}`;
+  const history = JSON.parse(localStorage.getItem(historyKey) || "[]");
+  history.push({ item: item.name, rarity: item.rarity, time: Date.now() });
+  localStorage.setItem(historyKey, JSON.stringify(history.slice(-50)));
+}
+
+function animatePortal() {
+  const ring = document.querySelector(".portal-ring");
+  ring.classList.add("flash");
+  setTimeout(() => ring.classList.remove("flash"), 600);
+}
+
+function engagePortal() {
+  if (!displayName) {
+    document.getElementById("dropResult").textContent =
+      "Save a display name to log your pulls.";
+    document.getElementById("nameInput").focus();
+    return;
+  }
+  animatePortal();
+  const pull = weightedPull();
+  savePull(pull);
+  document.getElementById("dropResult").innerHTML =
+    `<strong>${pull.name}</strong> unlocked · <span style="color:${pull.color}">${pull.rarity}</span>`;
+  loadInventory();
+  loadHistory();
+}
+
+function wireCtas() {
+  document.querySelectorAll("[data-target]").forEach((link) => {
+    link.addEventListener("click", (e) => {
+      const target = link.getAttribute("data-target");
+      if (target) {
+        e.preventDefault();
+        const el = document.querySelector(target);
+        el?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    });
+  });
+}
+
+function init() {
+  renderProducts();
+  renderRarityMeter();
+  renderLegend();
+  loadName();
+  loadInventory();
+  loadHistory();
+
+  document.getElementById("saveName").addEventListener("click", saveName);
+  document
+    .getElementById("nameInput")
+    .addEventListener("keydown", (e) => e.key === "Enter" && saveName());
+  document.getElementById("clearName").addEventListener("click", clearName);
+  document
+    .getElementById("unboxButton")
+    .addEventListener("click", engagePortal);
+  document.getElementById("labCta").addEventListener("click", (e) => {
+    e.preventDefault();
+    document.getElementById("unboxButton").focus();
+  });
+  wireCtas();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/style.css
+++ b/style.css
@@ -1,34 +1,684 @@
-body {
-  background: black;
-  color: pink;
-  font-family: 'Arial', sans-serif;
-  text-align: center;
-  margin: 0;
-  overflow-x: hidden;
+:root {
+  --bg: #030712;
+  --surface: #0c1324;
+  --surface-2: #111a2f;
+  --frost: #7ee8fa;
+  --frost-2: #80ffea;
+  --ice: #c3e7ff;
+  --accent: #9b8cff;
+  --text: #e8f1ff;
+  --muted: #8fa4c3;
+  --danger: #ff7eb6;
+  --success: #9ff3c2;
+  --warning: #ffd166;
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--text);
 }
-.header { padding: 20px; animation: glow 2s infinite alternate; }
-@keyframes glow { from { text-shadow: 0 0 5px #ff99cc; } to { text-shadow: 0 0 25px #ff3399; } }
-.centerpiece { margin: 20px auto; }
-.bodhi-img { width: 400px; border: 5px solid pink; border-radius: 20px;
-  box-shadow: 0 0 40px pink; animation: pulse 3s infinite; cursor: pointer; }
-@keyframes pulse { 0%{transform:scale(1);}50%{transform:scale(1.05);}100%{transform:scale(1);} }
-#candles,#gifts,#guestbook{margin:30px auto;padding:20px;background:rgba(255,20,147,0.1);
-  border-radius:10px;width:60%;}
-.candle,.gift{font-size:2em;margin:5px;}
-.heart,.balloon,.confetti,.lantern{position:fixed;animation:fall 10s linear infinite;}
-@keyframes fall { to { transform: translateY(110vh); } }
-.theme-emo { background:#111;color:#ff66ff; }
-.theme-serene { background:#fffafc;color:#333; }
-#fireworksCanvas{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;}
-.angel-wings{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);font-size:8em;
-  opacity:0;animation:wingFade 6s ease-in-out;}
-@keyframes wingFade { 0%{opacity:0;}20%{opacity:1;}80%{opacity:1;}100%{opacity:0;} }
 
-#visitorCount{margin:10px;font-weight:bold;}
-#share{margin:20px auto;}
-#share button{padding:10px 20px;font-size:1em;cursor:pointer;}
+* {
+  box-sizing: border-box;
+}
 
-@media (max-width:600px){
-  .bodhi-img{width:80%;}
-  #candles,#gifts,#guestbook{width:90%;}
+body {
+  margin: 0;
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(126, 232, 250, 0.08),
+      transparent 40%
+    ),
+    radial-gradient(
+      circle at 80% 0%,
+      rgba(155, 140, 255, 0.12),
+      transparent 45%
+    ),
+    linear-gradient(145deg, #040712 0%, #0a0f1c 60%, #060912 100%);
+  color: var(--text);
+  min-height: 100vh;
+  letter-spacing: 0.01em;
+  scroll-behavior: smooth;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.locked {
+  opacity: 0.6;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 32px;
+  position: sticky;
+  top: 0;
+  background: rgba(4, 7, 18, 0.9);
+  border-bottom: 1px solid rgba(126, 232, 250, 0.2);
+  backdrop-filter: blur(8px);
+  z-index: 10;
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--frost);
+}
+
+.nav-links {
+  display: flex;
+  gap: 16px;
+}
+
+.nav-link {
+  padding: 8px 12px;
+  border-radius: 999px;
+  color: var(--muted);
+  transition:
+    color 0.2s ease,
+    background 0.2s ease;
+}
+
+.nav-link:hover {
+  color: var(--text);
+  background: rgba(126, 232, 250, 0.08);
+}
+
+.session-pill {
+  padding: 8px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(126, 232, 250, 0.3);
+  color: var(--frost);
+  background: rgba(126, 232, 250, 0.08);
+  font-size: 0.9rem;
+}
+
+.login-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 32px;
+  background: linear-gradient(
+    90deg,
+    rgba(126, 232, 250, 0.08),
+    rgba(155, 140, 255, 0.1)
+  );
+  border-bottom: 1px solid rgba(126, 232, 250, 0.25);
+  gap: 16px;
+}
+
+.login-banner.active {
+  border-color: rgba(126, 232, 250, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(126, 232, 250, 0.2);
+}
+
+.banner-text {
+  color: var(--ice);
+  font-size: 0.95rem;
+}
+
+.banner-form {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.banner-form input {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(126, 232, 250, 0.3);
+  color: var(--text);
+  padding: 10px 12px;
+  border-radius: 10px;
+  min-width: 180px;
+}
+
+.banner-form button {
+  background: linear-gradient(135deg, var(--frost), var(--accent));
+  border: none;
+  color: #05070f;
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.banner-form button.ghost {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(126, 232, 250, 0.3);
+  color: var(--text);
+}
+
+.banner-form.has-name input,
+.banner-form.has-name #saveName {
+  display: none;
+}
+
+main {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  align-items: center;
+  background:
+    radial-gradient(
+      circle at 15% 30%,
+      rgba(126, 232, 250, 0.15),
+      transparent 45%
+    ),
+    radial-gradient(
+      circle at 80% 10%,
+      rgba(155, 140, 255, 0.2),
+      transparent 40%
+    ),
+    var(--surface);
+  border: 1px solid rgba(126, 232, 250, 0.15);
+  padding: 32px;
+  border-radius: 20px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 3vw, 3rem);
+  margin: 8px 0 12px;
+}
+.hero .lede {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: var(--frost);
+  margin: 0 0 8px;
+}
+
+.cta-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 18px 0;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.2s ease,
+    border 0.2s ease;
+}
+
+.cta.primary {
+  background: linear-gradient(135deg, var(--frost), var(--accent));
+  color: #05070f;
+  box-shadow: 0 10px 30px rgba(126, 232, 250, 0.25);
+}
+
+.cta.ghost {
+  border: 1px solid rgba(126, 232, 250, 0.4);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.cta.link {
+  color: var(--frost);
+  padding: 10px 0;
+  border: none;
+  background: transparent;
+  font-weight: 600;
+}
+
+.cta:hover {
+  transform: translateY(-2px);
+}
+
+.hero-stats {
+  list-style: none;
+  padding: 0;
+  margin: 14px 0 0;
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  color: var(--muted);
+}
+
+.hero-stats span {
+  display: block;
+  color: var(--text);
+  font-weight: 700;
+}
+
+.hero-visual {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 18px;
+}
+
+.frost-orb {
+  position: relative;
+  width: 260px;
+  height: 260px;
+  display: grid;
+  place-items: center;
+}
+
+.frost-core {
+  width: 180px;
+  height: 180px;
+  border-radius: 30px;
+  background: linear-gradient(
+    160deg,
+    rgba(126, 232, 250, 0.8),
+    rgba(155, 140, 255, 0.7)
+  );
+  filter: drop-shadow(0 15px 45px rgba(126, 232, 250, 0.35));
+  animation: float 6s ease-in-out infinite;
+}
+
+.halo {
+  position: absolute;
+  width: 250px;
+  height: 250px;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    rgba(126, 232, 250, 0.2),
+    transparent 60%
+  );
+  filter: blur(14px);
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+
+.rarity-meter {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(126, 232, 250, 0.2);
+  border-radius: 14px;
+  padding: 12px;
+}
+
+.meter-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin-bottom: 8px;
+}
+
+.meter-bars {
+  display: grid;
+  gap: 8px;
+}
+
+.meter-row {
+  display: grid;
+  grid-template-columns: 110px 1fr 70px;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.meter-row span {
+  color: var(--text);
+}
+
+.meter-track {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  overflow: hidden;
+  height: 10px;
+}
+
+.meter-fill {
+  height: 100%;
+  border-radius: inherit;
+  transition: width 0.35s ease;
+}
+
+.section {
+  background: var(--surface);
+  border: 1px solid rgba(126, 232, 250, 0.12);
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-end;
+  margin-bottom: 22px;
+  flex-wrap: wrap;
+}
+
+.section h2 {
+  margin: 4px 0;
+  font-size: 1.8rem;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  background: var(--surface-2);
+  border: 1px solid rgba(126, 232, 250, 0.12);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+}
+
+.card .badge {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #05070f;
+}
+
+.card h3 {
+  margin: 0;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.price {
+  font-weight: 700;
+  color: var(--ice);
+}
+
+.tagline {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.frost-lab {
+  background: linear-gradient(
+    135deg,
+    rgba(8, 16, 35, 0.9),
+    rgba(8, 18, 30, 0.9)
+  );
+}
+
+.lab-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.lab-portal {
+  background: var(--surface-2);
+  border: 1px solid rgba(126, 232, 250, 0.15);
+  border-radius: 16px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.portal-frame {
+  position: relative;
+  background: radial-gradient(
+    circle at 40% 40%,
+    rgba(126, 232, 250, 0.25),
+    rgba(5, 9, 20, 0.95)
+  );
+  border: 1px solid rgba(126, 232, 250, 0.18);
+  border-radius: 18px;
+  padding: 26px;
+  min-height: 220px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.portal-core {
+  position: relative;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(126, 232, 250, 0.25),
+    rgba(155, 140, 255, 0.3)
+  );
+  display: grid;
+  place-items: center;
+  animation: pulse 4s ease-in-out infinite;
+}
+
+.portal-ring {
+  position: absolute;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  border: 1px dashed rgba(126, 232, 250, 0.4);
+  animation: spin 8s linear infinite;
+}
+
+.portal-ring.flash {
+  box-shadow: 0 0 0 12px rgba(126, 232, 250, 0.12);
+  transition: box-shadow 0.3s ease;
+}
+
+.portal-flare {
+  position: absolute;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(126, 232, 250, 0.35),
+    transparent 60%
+  );
+  filter: blur(10px);
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+.crate {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(126, 232, 250, 0.2);
+  color: var(--ice);
+  font-weight: 700;
+}
+
+.cta.wide {
+  width: 100%;
+  justify-content: center;
+}
+
+.drop-result {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(126, 232, 250, 0.18);
+  border-radius: 10px;
+  padding: 12px;
+  color: var(--ice);
+  min-height: 48px;
+}
+
+.legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(126, 232, 250, 0.12);
+  border-radius: 10px;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 4px;
+}
+
+.lab-inventory {
+  display: grid;
+  gap: 12px;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(126, 232, 250, 0.12);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.panel h3 {
+  margin: 4px 0 0;
+}
+
+.pill {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(126, 232, 250, 0.18);
+  color: var(--frost);
+  border: 1px solid rgba(126, 232, 250, 0.3);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.pill.ghost {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  border-color: rgba(126, 232, 250, 0.18);
+}
+
+.inventory-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.inventory-card {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(126, 232, 250, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.inventory-card span {
+  font-weight: 700;
+  color: var(--text);
+}
+
+.history {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: grid;
+  gap: 10px;
+}
+
+.history li {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(126, 232, 250, 0.12);
+  border-radius: 10px;
+  padding: 10px;
+  color: var(--muted);
+}
+
+@media (max-width: 700px) {
+  .topbar {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .nav-links {
+    width: 100%;
+    justify-content: center;
+  }
+  .login-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .hero-visual {
+    align-items: center;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the memorial layout with a Frostborne-themed single-page hero, product grid, rarity meter, and Frost Lab sections
- add a login banner that stores a display name in localStorage, shows session status, and now includes switch-name handling with refreshed portal messaging
- implement portal unboxing CTA flow with rarity legend, anchor-scroll CTAs, and inventory/history panels tied to the saved name

## Testing
- npx prettier --check index.html script.js style.css

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_691e6105320483239d032178ad20631b)